### PR TITLE
犬を黙らせる

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,1 @@
+.rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+AsciiComments:
+  Enabled: false
+
+Syle/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Style/DotPosition:
+  EnforcedStyle: leading


### PR DESCRIPTION
rubocop.ymlとhound.yml(シンボリックリンク)を追加しました。
※当初create-modelブランチで作りましたが、さっさと取り込んだほうがいいかなと思ってcherry-pickしました。
