### PR TITLE
dotenvを入れました

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ Session.vim
 
 # tag file
 tags
+
+# dotenv
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem 'pry-doc'
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
+  gem 'dotenv-rails'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,10 @@ GEM
     daemons (1.2.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    dotenv (2.0.2)
+    dotenv-rails (2.0.2)
+      dotenv (= 2.0.2)
+      railties (~> 4.0)
     equalizer (0.0.11)
     erubis (2.7.0)
     eventmachine (1.0.7)
@@ -264,6 +268,7 @@ DEPENDENCIES
   bower-rails
   byebug
   coffee-rails (~> 4.1.0)
+  dotenv-rails
   jbuilder (~> 2.0)
   jquery-rails
   minitest-power_assert


### PR DESCRIPTION
開発環境の環境変数用に[dotenv](https://github.com/bkeepers/dotenv)を入れました。

`#{rails_root}/.env`というファイルを作成してイカの設定を追加すると`ENV`から参照できます。
最後の行を空行にしないとちゃんと認識してくれなかった...

```
TWITTER_SECRET=hoge
```
