### PR TITLE
twitterログインをできるようにする

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class SessionsController < ApplicationController
-  before_action -> { request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:twitter] } unless Rails.env.production?
+  before_action -> { request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:twitter] } unless Twitter.login?
 
   def create
     user = User.find_or_create_from_auth_hash(auth_hash)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def sign_in_url
-    Rails.env.production? ? 'auth/twitter' : '/auth/developer'
+    Twitter.login? ? 'auth/twitter' : '/auth/developer'
   end
 end

--- a/config/initializers/twitter.rb
+++ b/config/initializers/twitter.rb
@@ -1,6 +1,13 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  # provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
-  unless Rails.env.production?
+  class Twitter
+    def self.login?
+      ENV['TWITTER_KEY'].present? && ENV['TWITTER_SECRET'].present?
+    end
+  end
+
+  if Twitter.login?
+    provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
+  else
     provider :developer
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({


### PR DESCRIPTION
this will be closed #33
# できること

twitterログイン
- `TWITTER_KEY`には consumer key 、 `TWITTER_SECRET`にはconsumer secretが定義しておくこと
- 定義していない場合、developerを利用する
- #37がマージされると確認が楽かも
# やらないこと
- productionで`TWITTER_KEY`と`TWITTER_SECRET`が設定されていなかったらエラーにする
  - 別PRで対応する
