### PR TITLE
ログイン後はrootパスへのアクセスをpractices#indexへリダイレクトする

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,5 @@
 class TopController < ApplicationController
   def index
+    redirect_to practices_path if logged_in?
   end
 end

--- a/test/controllers/top_controller_test.rb
+++ b/test/controllers/top_controller_test.rb
@@ -5,4 +5,10 @@ class TopControllerTest < ActionController::TestCase
     get :index
     assert_response :success
   end
+
+  test "should redirect practices index if user logged in" do
+    session[:user_id] = User.first.id
+    get :index
+    assert_redirected_to practices_path
+  end
 end


### PR DESCRIPTION
# やったこと

ユーザーはログイン後 `http://xxxx.com/`にアクセスすると習慣の一覧画面に遷移する
